### PR TITLE
Use Alpine as base image in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:19 AS builder
+FROM node:19-alpine AS builder
 
 # Create app directory
 WORKDIR /app
@@ -15,7 +15,7 @@ COPY . .
 
 RUN npm run build
 
-FROM node:19
+FROM node:19-alpine
 
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/package*.json ./


### PR DESCRIPTION
It makes the final image around half the previous size. 567 MB vs 1.39 GB