### PR TITLE
feat(git): :technologist: vs code git commit signing

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -26,7 +26,8 @@
     "gruntfuggly.todo-tree",
     "pflannery.vscode-versionlens",
     "vscode-icons-team.vscode-icons",
-    "vivaxy.vscode-conventional-commits"
+    "vivaxy.vscode-conventional-commits",
+    "prisma.prisma"
   ],
   // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
   "unwantedRecommendations": []

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,5 @@
 {
   "editor.bracketPairColorization.enabled": true,
-  "editor.codeActionsOnSave": ["source.formatDocument", "source.fixAll.eslint"],
   "editor.cursorBlinking": "phase",
   "editor.cursorSmoothCaretAnimation": true,
   "editor.defaultFormatter": "esbenp.prettier-vscode",
@@ -11,11 +10,14 @@
   "editor.minimap.renderCharacters": false,
   "editor.minimap.showSlider": "always",
   "editor.tabSize": 2,
+  "git.enableCommitSigning": true,
   "editor.wordWrapColumn": 100,
   "files.eol": "\n",
   "files.trimTrailingWhitespace": true,
   "editor.codeActionsOnSave": {
-    "source.organizeImports": true
+    "source.organizeImports": true,
+    "source.formatDocument": true,
+    "source.fixAll.eslint": true
   },
   "cSpell.customDictionaries": {
     "custom-dictionary-workspace": {
@@ -26,7 +28,7 @@
     }
   },
   "[dotenv]": {
-    "editor.defaultFormatter": "foxundermoon.shell-format"
+    "editor.defaultFormatter": "IronGeek.vscode-env"
   },
   "[prisma]": {
     "editor.defaultFormatter": "Prisma.prisma"


### PR DESCRIPTION
Enable commit signing in VS Code by default

Also includes fix of duplicated configurations in VS Code settings