### PR TITLE
ci: :green_heart: remove arm64 build

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -55,4 +55,4 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64


### PR DESCRIPTION
I had to remove arm64 platform from the images since prisma client do not seem to support arm64 yet