### PR TITLE
Fix README invite URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ If after reading the guide you are still experiencing issues, feel free to join 
 
 **Xyter** is in continuous development, and is currently still in **beta**!
 
-Join us on our [Official Discord Server](https://discord.gg/red)!
+Join us on our [Official Discord Server](https://discord.zyner.org)!
 
 # License
 


### PR DESCRIPTION
Over at Red, we've had a user that has come to our #support channel for help with this bot, which we don't provide. You should not be directing your users to Red's server for a specific instance, moreover if it's not a derivative of Red-DiscordBot or runs on unsupported platforms. The amendment I have made has changed that invite URL to link to your Discord server instead.