### PR TITLE
fix(audits): :bug: Fix audit log sent when an url is sent that adds a…

### DIFF
--- a/src/events/messageUpdate/audits.ts
+++ b/src/events/messageUpdate/audits.ts
@@ -12,6 +12,9 @@ export default {
 
     if (!member.joinedAt) throw new Error("Can not find member joined at");
 
+    // Do not send audit log when an message contains an link and that links creates an embed
+    if (!newMessage.editedTimestamp) return;
+
     const embed = new EmbedBuilder()
       .setAuthor({
         name: "Message Updated",


### PR DESCRIPTION
…n embed to the message #514

Fixed so the bot wont send a messageUpdate audit log when links are sent