### PR TITLE
fix: :ambulance: fix bot crash if oldMessage content undefined

### DIFF
--- a/src/events/messageUpdate/audits.ts
+++ b/src/events/messageUpdate/audits.ts
@@ -15,6 +15,9 @@ export default {
     // Do not send audit log when an message contains an link and that links creates an embed
     if (!newMessage.editedTimestamp) return;
 
+    // Do not send audit log if oldMessage content is not found
+    if (!oldMessage.content) return;
+
     const embed = new EmbedBuilder()
       .setAuthor({
         name: "Message Updated",


### PR DESCRIPTION
Added an if statement to return if oldMessage.content is undefined