### PR TITLE
fix: :zap: replace template string with double quote

### DIFF
--- a/src/commands/settings/subcommands/quotes/index.ts
+++ b/src/commands/settings/subcommands/quotes/index.ts
@@ -12,7 +12,7 @@ import sendResponse from "../../../../utils/sendResponse";
 export const builder = (command: SlashCommandSubcommandBuilder) => {
   return command
     .setName("quotes")
-    .setDescription(`Configure quotes module`)
+    .setDescription("Configure quotes module")
     .addBooleanOption((option) =>
       option.setName("status").setDescription("Status").setRequired(true)
     )


### PR DESCRIPTION
Replaced with double quote as a template string is unneeded