### PR TITLE
build: :art: Use COPY instead of ADD for files and folders

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ENV NODE_ENV production
 
 # Add mysql precheck
 RUN apk add --no-cache mysql-client
-ADD docker-entrypoint.sh /docker-entrypoint.sh
+COPY docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh
 
 # Copy files


### PR DESCRIPTION
For items like files and directories that do not require ADD’s tar auto-extraction capability, you should always use COPY. Read more about it here.