### PR TITLE
fix: :bug: remove expiresAt when searching cooldown table

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xyter",
-  "version": "2.1.1",
+  "version": "2.1.2-dev.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "xyter",
-      "version": "2.1.1",
+      "version": "2.1.2-dev.1",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@prisma/client": "^4.7.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xyter",
-  "version": "2.1.1",
+  "version": "2.1.2-dev.1",
   "private": true,
   "description": "A multi purpose Discord bot written in TypeScript with Discord.js",
   "main": "dist/index.js",

--- a/src/handlers/CooldownManager.ts
+++ b/src/handlers/CooldownManager.ts
@@ -25,7 +25,6 @@ class CooldownManager {
       await prisma.cooldown.updateMany({
         where: {
           cooldownItem,
-          expiresAt,
           guild: guild ? { id: guild.id } : undefined,
           user: user ? { id: user.id } : undefined,
         },


### PR DESCRIPTION
This was a "bug" that made Prisma  create new cooldowns whenever it exceeded the expiresAt Datetime