### PR TITLE
Fix cooldown update and creation and add a spam penalty

### DIFF
--- a/src/events/interactionCreate/interactionTypes/handleCommandInteraction/index.ts
+++ b/src/events/interactionCreate/interactionTypes/handleCommandInteraction/index.ts
@@ -27,7 +27,11 @@ export default async function handleCommandInteraction(
     const { guildCooldown, userCooldown, guildMemberCooldown } =
       await cooldownManager.checkCooldowns(cooldownItem, guild, user);
 
-    if (guildCooldown || userCooldown || guildMemberCooldown) {
+    if (
+      (guildCooldown && guildCooldown.expiresAt > new Date()) ||
+      (userCooldown && userCooldown.expiresAt > new Date()) ||
+      (guildMemberCooldown && guildMemberCooldown.expiresAt > new Date())
+    ) {
       await handleCooldown(
         interaction,
         guildCooldown,

--- a/src/events/messageCreate/components/earnCredits.ts
+++ b/src/events/messageCreate/components/earnCredits.ts
@@ -56,7 +56,10 @@ async function isUserOnCooldown(guild: Guild, author: User): Promise<boolean> {
     guild,
     author
   );
-  return cooldownActive !== null;
+
+  if (!cooldownActive) return false;
+
+  return cooldownActive.expiresAt > new Date();
 }
 
 async function setCooldown(guild: Guild, user: User) {

--- a/src/events/messageCreate/components/earnCredits.ts
+++ b/src/events/messageCreate/components/earnCredits.ts
@@ -25,7 +25,37 @@ export default async (message: Message) => {
   }
 
   try {
-    await creditsManager.give(guild, author, 1);
+    const filter = (msg: Message) => {
+      return msg.author == message.author;
+    };
+
+    if (message.author.bot) return;
+
+    const checkTime = 5 * 1000; // Milliseconds
+    const maxMessageAmount = 3; // Anti Spam Rule, remove 1 credit per message above this value during "checkTime" variable
+    const amount = 1; //Amount to give if valid
+    const penaltyAmount = 2; //Amount to take if invalid
+
+    await message.channel
+      .awaitMessages({ filter, time: checkTime })
+      .then(async (messages) => {
+        // Sounds logic with <= but since it goes down to 0 it should be < since we do not want to add at 3 too since then we add 4
+        // If user is below "maxMessageAmount"
+        if (messages.size < maxMessageAmount) {
+          await creditsManager.give(guild, author, amount);
+        }
+
+        // Sounds logic with > but since it goes down to 0 it should be >= since we want to remove at 0 too
+        // If user exceeds "maxMessageAmount"
+        if (messages.size >= maxMessageAmount) {
+          await creditsManager.take(guild, author, penaltyAmount);
+        }
+
+        // When it finished calculating results
+        if (messages.size === 0) {
+          await setCooldown(guild, author);
+        }
+      });
   } catch (error: unknown) {
     logger.error(
       `Failed to give credits to user ${author.username} in guild ${
@@ -33,8 +63,6 @@ export default async (message: Message) => {
       } when sending a message: ${String(error)}`
     );
   }
-
-  await setCooldown(guild, author);
 };
 
 function isMessageValid(
@@ -44,6 +72,8 @@ function isMessageValid(
   content: string
 ): boolean {
   return (
+    guild &&
+    author &&
     !author.bot &&
     channel.type === ChannelType.GuildText &&
     content.length >= MINIMUM_LENGTH

--- a/src/handlers/CooldownManager.ts
+++ b/src/handlers/CooldownManager.ts
@@ -18,21 +18,19 @@ class CooldownManager {
       user: user ? { connect: { id: user.id } } : undefined,
     };
 
-    const { guildCooldown, guildMemberCooldown, userCooldown } =
-      await this.checkCooldowns(cooldownItem, guild, user);
+    const existingCooldown = await this.checkCooldown(
+      cooldownItem,
+      guild,
+      user
+    );
 
-    if (guildCooldown || guildMemberCooldown || userCooldown) {
-      await prisma.cooldown.updateMany({
+    if (existingCooldown) {
+      await prisma.cooldown.update({
         where: {
-          cooldownItem,
-          guild: guild ? { id: guild.id } : undefined,
-          user: user ? { id: user.id } : undefined,
+          id: existingCooldown.id,
         },
         data: {
-          cooldownItem,
           expiresAt,
-          guildId: guild ? guild.id : undefined,
-          userId: user ? user.id : undefined,
         },
       });
     } else {
@@ -62,7 +60,6 @@ class CooldownManager {
       cooldownItem,
       guild: guild ? { id: guild.id } : null,
       user: user ? { id: user.id } : null,
-      expiresAt: { gte: new Date() },
     };
     const cooldown = await prisma.cooldown.findFirst({ where });
     const duration = Date.now() - start;


### PR DESCRIPTION
This pull request should fix update action when a cooldown is expired, before it created new ones leaving the old ones expired and this increased the cooldown table too much.

This also adds a penalty cost if a user spam messages to get credits :1st_place_medal: 